### PR TITLE
[Compilation fix] Ensure proper aligned_allocator definition by using vector-aligned

### DIFF
--- a/examples/clarky-section/clarky-section.cpp
+++ b/examples/clarky-section/clarky-section.cpp
@@ -22,11 +22,11 @@ using namespace Vortexje;
 static const double pi = 3.141592653589793238462643383279502884;
 
 // Load airfoil data from file:
-static vector<Vector3d, Eigen::aligned_allocator<Vector3d> >
+static vector_aligned<Vector3d>
 read_airfoil(const std::string &filename, int &trailing_edge_point_id)
 {
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > upper_points;
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > lower_points;
+    vector_aligned<Vector3d> upper_points;
+    vector_aligned<Vector3d> lower_points;
     
     // Parse file:
     ifstream f;
@@ -67,7 +67,7 @@ read_airfoil(const std::string &filename, int &trailing_edge_point_id)
     f.close();
     
     // Assemble entire airfoil:
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > points;
+    vector_aligned<Vector3d> points;
     
     for (int i = 0; i < (int) upper_points.size() - 1; i++)
         points.push_back(upper_points[i]);
@@ -93,7 +93,7 @@ main(int argc, char **argv)
     
     // Load airfoil data:
     int trailing_edge_point_id;
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > clarky_airfoil = read_airfoil("clarky.dat", trailing_edge_point_id);
+    vector_aligned<Vector3d> clarky_airfoil = read_airfoil("clarky.dat", trailing_edge_point_id);
     
     // Create lifting surface object:
     shared_ptr<LiftingSurface> wing(new LiftingSurface("main"));
@@ -112,7 +112,7 @@ main(int argc, char **argv)
     vector<vector<int> > panel_strips;
     
     for (int i = 0; i < n_airfoils; i++) {
-        vector<Vector3d, Eigen::aligned_allocator<Vector3d> > airfoil_points;
+        vector_aligned<Vector3d> airfoil_points;
         for (int j = 0; j < (int) clarky_airfoil.size(); j++)
             airfoil_points.push_back(Vector3d(chord * clarky_airfoil[j](0), chord * clarky_airfoil[j](1), i * span / (double) (n_airfoils - 1)));
              

--- a/examples/hawt/hawt.cpp
+++ b/examples/hawt/hawt.cpp
@@ -47,7 +47,7 @@ public:
         vector<vector<int> > panel_strips;
         
         for (int i = 0; i < (int) blade_dr.size(); i++) {
-            vector<Vector3d, Eigen::aligned_allocator<Vector3d> > airfoil_points;
+            vector_aligned<Vector3d> airfoil_points;
             for (int j = 0; j < (int) unscaled_airfoil_points.size(); j++) {
                 Vector3d airfoil_point(blade_chord[i] * (unscaled_airfoil_points[j](0) - 0.25),
                                        blade_thickness[i] / unscaled_airfoil_thickness * unscaled_airfoil_points[j](1),
@@ -75,7 +75,7 @@ public:
     }
     
 private:
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > unscaled_airfoil_points;
+    vector_aligned<Vector3d> unscaled_airfoil_points;
     double unscaled_airfoil_thickness;
     
     int trailing_edge_point_id;
@@ -89,8 +89,8 @@ private:
     void
     read_airfoil(const std::string &filename)
     {
-        vector<Vector3d, Eigen::aligned_allocator<Vector3d> > upper_points;
-        vector<Vector3d, Eigen::aligned_allocator<Vector3d> > lower_points;
+        vector_aligned<Vector3d> upper_points;
+        vector_aligned<Vector3d> lower_points;
         
         // Parse file:
         ifstream f;

--- a/examples/naca0012-section-oscillation/naca0012-section-oscillation.cpp
+++ b/examples/naca0012-section-oscillation/naca0012-section-oscillation.cpp
@@ -46,7 +46,7 @@ main (int argc, char **argv)
     vector<vector<int> > panel_strips;
     
     for (int i = 0; i < n_airfoils; i++) {
-        vector<Vector3d, Eigen::aligned_allocator<Vector3d> > airfoil_points =
+        vector_aligned<Vector3d> airfoil_points =
             NACA4AirfoilGenerator::generate(0, 0, 0.12, true, chord, n_points_per_airfoil, trailing_edge_point_id);
         for (int j = 0; j < (int) airfoil_points.size(); j++)
             airfoil_points[j](2) += i * span / (double) (n_airfoils - 1);

--- a/examples/vawt/vawt.cpp
+++ b/examples/vawt/vawt.cpp
@@ -53,7 +53,7 @@ public:
         vector<vector<int> > panel_strips;
         
         for (int i = 0; i < n_airfoils; i++) {
-            vector<Vector3d, Eigen::aligned_allocator<Vector3d> > airfoil_points =
+            vector_aligned<Vector3d> airfoil_points =
                 NACA4AirfoilGenerator::generate(0, 0, 0.12, true, chord, n_points_per_airfoil, trailing_edge_point_id);
             for (int j = 0; j < (int) airfoil_points.size(); j++)
                 airfoil_points[j](2) += i * span / (double) (n_airfoils - 1);
@@ -98,7 +98,7 @@ public:
         vector<int> prev_nodes;
         
         for (int i = 0; i < n_layers; i++) {
-            vector<Vector3d, Eigen::aligned_allocator<Vector3d> > points =
+            vector_aligned<Vector3d> points =
                 EllipseGenerator::generate(r, r, n_points);
             for (int j = 0; j < (int) points.size(); j++)
                 points[j](2) += i * h / (double) (n_layers - 1);

--- a/tests/elliptic-planform/test-elliptic-planform.cpp
+++ b/tests/elliptic-planform/test-elliptic-planform.cpp
@@ -70,7 +70,7 @@ run_test(double alpha)
         double chord_y  = chord * sqrt(1.0 - pow(2.0 * y / span, 2));
         double offset_x = (chord - chord_y) / 2.0;
         
-        vector<Vector3d, Eigen::aligned_allocator<Vector3d> > airfoil_points;
+        vector_aligned<Vector3d> airfoil_points;
         if (i == 0 || i == n_airfoils - 1) {
             Vector3d tip_point(0.0, 0.0, 0.0);
             for (int j = 0; j < n_points_per_airfoil; j++)

--- a/tests/interpolation-layer/test-interpolation-layer.cpp
+++ b/tests/interpolation-layer/test-interpolation-layer.cpp
@@ -50,13 +50,13 @@ main (int argc, char **argv)
     double alpha = pi * 5.0 / 180.0;
     AngleAxis<double> rotation(-alpha, Vector3d::UnitZ());
     
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > airfoil_points =
+    vector_aligned<Vector3d> airfoil_points =
         NACA4AirfoilGenerator::generate(0.09, 0.4, 0.12, true, chord, n_points_per_airfoil, trailing_edge_point_id);
     for (int i = 0; i < n_points_per_airfoil; i++)
         airfoil_points[i] = rotation * airfoil_points[i];
         
     for (int i = 0; i < n_airfoils; i++) {
-        vector<Vector3d, Eigen::aligned_allocator<Vector3d> > translated_airfoil_points = airfoil_points;
+        vector_aligned<Vector3d> translated_airfoil_points = airfoil_points;
         for (int j = 0; j < (int) airfoil_points.size(); j++)
             translated_airfoil_points[j](2) += i * span / (double) (n_airfoils - 1);
              

--- a/tests/naca0012-airfoil/test-naca0012-airfoil.cpp
+++ b/tests/naca0012-airfoil/test-naca0012-airfoil.cpp
@@ -46,7 +46,7 @@ run_test(double alpha)
     vector<vector<int> > panel_strips;
     
     for (int i = 0; i < n_airfoils; i++) {
-        vector<Vector3d, Eigen::aligned_allocator<Vector3d> > airfoil_points =
+        vector_aligned<Vector3d> airfoil_points =
             NACA4AirfoilGenerator::generate(0, 0, 0.12, true, chord, n_points_per_airfoil, trailing_edge_point_id);
         for (int j = 0; j < (int) airfoil_points.size(); j++)
             airfoil_points[j](2) += i * span / (double) (n_airfoils - 1);
@@ -102,7 +102,7 @@ int
 main (int argc, char **argv)
 {
     // Load reference values.
-    std::vector<Vector3d, Eigen::aligned_allocator<Vector3d> > reference_results;
+    vector_aligned<Vector3d> reference_results;
     
     ifstream f;
     f.open("naca0012-reference-data.txt");

--- a/tests/vortex-core/test-vortex-core.cpp
+++ b/tests/vortex-core/test-vortex-core.cpp
@@ -47,7 +47,7 @@ main (int argc, char **argv)
     vector<vector<int> > panel_strips;
     
     for (int i = 0; i < n_airfoils; i++) {
-        vector<Vector3d, Eigen::aligned_allocator<Vector3d> > airfoil_points =
+        vector_aligned<Vector3d> airfoil_points =
             NACA4AirfoilGenerator::generate(0, 0, 0.12, true, chord, n_points_per_airfoil, trailing_edge_point_id);
         for (int j = 0; j < (int) airfoil_points.size(); j++)
             airfoil_points[j](2) += i * span / (double) (n_airfoils - 1);

--- a/vortexje/field-writers/vtk-field-writer.cpp
+++ b/vortexje/field-writers/vtk-field-writer.cpp
@@ -60,7 +60,7 @@ VTKFieldWriter::write_velocity_field(const Solver &solver, const std::string &fi
     // Compute velocity vector field:
     cout << "VTKFieldWriter: Computing velocity vector field." << endl;
 
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > velocities;
+    vector_aligned<Vector3d> velocities;
     velocities.resize(nx * ny * nz);
     
     int i;
@@ -88,7 +88,7 @@ VTKFieldWriter::write_velocity_field(const Solver &solver, const std::string &fi
     // Velocity vector field;    
     f << "VECTORS Velocity double" << endl;
     
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> >::const_iterator it;
+    vector_aligned<Vector3d>::const_iterator it;
     for (it = velocities.begin(); it != velocities.end(); it++) {
         Vector3d v = *it;
         f << v(0) << " " << v(1) << " " << v(2) << endl;

--- a/vortexje/shape-generators/airfoils/naca4-airfoil-generator.cpp
+++ b/vortexje/shape-generators/airfoils/naca4-airfoil-generator.cpp
@@ -76,7 +76,7 @@ compute_y_t(double x, double max_camber, double max_camber_dist, double max_thic
    
    @note See S. Yon, J. Katz, and A. Plotkin, Effect of Airfoil (Trailing-Edge) Thickness on the Numerical Solution of Panel Methods Based on the Dirichlet Boundary Condition, AIAA Journal, Vol. 30, No. 3, March 1992, for the issues that may arise when using an infinitely thin trailing edge.
 */
-vector<Vector3d, Eigen::aligned_allocator<Vector3d> >
+vector_aligned<Vector3d>
 NACA4AirfoilGenerator::generate(double max_camber, double max_camber_dist, double max_thickness, bool finite_te_thickness, double chord, int n_points, int &trailing_edge_point_id)
 {
     if (n_points % 2 == 1) {
@@ -84,7 +84,7 @@ NACA4AirfoilGenerator::generate(double max_camber, double max_camber_dist, doubl
         exit(1);
     }
     
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > airfoil_points;
+    vector_aligned<Vector3d> airfoil_points;
     
     // Add upper nodes:
     for (int i = 0; i < n_points / 2; i++) {

--- a/vortexje/shape-generators/airfoils/naca4-airfoil-generator.hpp
+++ b/vortexje/shape-generators/airfoils/naca4-airfoil-generator.hpp
@@ -10,7 +10,8 @@
 #define __NACA4_AIRFOIL_GENERATOR_HPP__
 
 #include <Eigen/Core>
-#include <Eigen/StdVector>
+
+#include <vortexje/vector-aligned.hpp>
 
 namespace Vortexje
 {
@@ -23,7 +24,7 @@ namespace Vortexje
 class NACA4AirfoilGenerator
 {
 public:
-    static std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > generate(double max_camber, double max_camber_dist, double max_thickness, bool finite_te_thickness, double chord, int n_points, int &trailing_edge_point_id);
+    static vector_aligned<Eigen::Vector3d> generate(double max_camber, double max_camber_dist, double max_thickness, bool finite_te_thickness, double chord, int n_points, int &trailing_edge_point_id);
 };
 
 };

--- a/vortexje/shape-generators/ellipse-generator.cpp
+++ b/vortexje/shape-generators/ellipse-generator.cpp
@@ -25,10 +25,10 @@ static const double pi = 3.141592653589793238462643383279502884;
    
    @returns List of points.
 */
-vector<Vector3d, Eigen::aligned_allocator<Vector3d> >
+vector_aligned<Vector3d>
 EllipseGenerator::generate(double a, double b, int n_points)
 {
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > points;
+    vector_aligned<Vector3d> points;
     
     // Go in the clockwise (negative) direction, for consistency with the airfoil generators.
     double dt = -2 * pi / (double) n_points;

--- a/vortexje/shape-generators/ellipse-generator.hpp
+++ b/vortexje/shape-generators/ellipse-generator.hpp
@@ -10,7 +10,8 @@
 #define __ELLIPSE_GENERATOR_HPP__
 
 #include <Eigen/Core>
-#include <Eigen/StdVector>
+
+#include <vortexje/vector-aligned.hpp>
 
 namespace Vortexje
 {
@@ -23,7 +24,7 @@ namespace Vortexje
 class EllipseGenerator
 {
 public:
-    static std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > generate(double a, double b, int n_points);
+    static vector_aligned<Eigen::Vector3d> generate(double a, double b, int n_points);
 };
 
 };

--- a/vortexje/solver.cpp
+++ b/vortexje/solver.cpp
@@ -460,10 +460,10 @@ Solver::moment(const std::shared_ptr<Surface> &surface, const Eigen::Vector3d &x
    
    @returns A list of points tracing the streamline.
 */
-vector<Solver::SurfacePanelPoint, Eigen::aligned_allocator<Solver::SurfacePanelPoint> >
+vector_aligned<Solver::SurfacePanelPoint>
 Solver::trace_streamline(const SurfacePanelPoint &start) const
 {
-    vector<SurfacePanelPoint, Eigen::aligned_allocator<Solver::SurfacePanelPoint> > streamline;
+    vector_aligned<SurfacePanelPoint> streamline;
     
     SurfacePanelPoint cur(start.surface, start.panel, start.point);
     
@@ -1000,7 +1000,7 @@ Solver::update_wakes(double dt)
         cout << "Solver: Convecting wakes." << endl;
         
         // Compute velocity values at wake nodes, with the wakes in their original state:
-        vector<vector<Vector3d, Eigen::aligned_allocator<Vector3d> >, Eigen::aligned_allocator<vector<Vector3d> > > wake_velocities;
+        vector_aligned<vector_aligned<Vector3d> > wake_velocities;
         
         vector<shared_ptr<BodyData> >::const_iterator bdi;
         for (bdi = bodies.begin(); bdi != bodies.end(); bdi++) {
@@ -1010,7 +1010,7 @@ Solver::update_wakes(double dt)
             for (lsi = bd->body->lifting_surfaces.begin(); lsi != bd->body->lifting_surfaces.end(); lsi++) {
                 const shared_ptr<Body::LiftingSurfaceData> &d = *lsi;
                 
-                vector<Vector3d, Eigen::aligned_allocator<Vector3d> > local_wake_velocities;
+                vector_aligned<Vector3d> local_wake_velocities;
                 local_wake_velocities.resize(d->wake->n_nodes());
                 
                 int i;
@@ -1037,7 +1037,7 @@ Solver::update_wakes(double dt)
                 shared_ptr<Body::LiftingSurfaceData> d = *lsi;
                 
                 // Retrieve local wake velocities:
-                vector<Vector3d, Eigen::aligned_allocator<Vector3d> > &local_wake_velocities = wake_velocities[idx];
+                vector_aligned<Vector3d> &local_wake_velocities = wake_velocities[idx];
                 idx++;
                 
                 // Convect wake nodes that coincide with the trailing edge.
@@ -1137,7 +1137,7 @@ Solver::log(int step_number, SurfaceWriter &writer) const
             offset += d->surface->n_panels();
             
             vector<string> view_names;
-            vector<MatrixXd, Eigen::aligned_allocator<MatrixXd> > view_data;
+            vector_aligned<MatrixXd> view_data;
             
             view_names.push_back(VIEW_NAME_DOUBLET_DISTRIBUTION);
             view_data.push_back(non_lifting_surface_doublet_coefficients);
@@ -1184,7 +1184,7 @@ Solver::log(int step_number, SurfaceWriter &writer) const
             offset += d->lifting_surface->n_panels();
             
             vector<string> view_names;
-            vector<MatrixXd, Eigen::aligned_allocator<MatrixXd> > view_data;
+            vector_aligned<MatrixXd> view_data;
             
             view_names.push_back(VIEW_NAME_DOUBLET_DISTRIBUTION);
             view_data.push_back(lifting_surface_doublet_coefficients);
@@ -1484,12 +1484,12 @@ Eigen::Vector3d
 Solver::compute_velocity_interpolated(const Eigen::Vector3d &x, std::set<int> &ignore_set) const
 {
     // Lists of close velocities, ordered by primacy:
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > close_panel_velocities;
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > close_panel_edge_velocities;
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > interior_close_panel_velocities;
-    vector<Vector3d, Eigen::aligned_allocator<Vector3d> > interior_close_panel_edge_velocities;
+    vector_aligned<Vector3d> close_panel_velocities;
+    vector_aligned<Vector3d> close_panel_edge_velocities;
+    vector_aligned<Vector3d> interior_close_panel_velocities;
+    vector_aligned<Vector3d> interior_close_panel_edge_velocities;
     
-    vector<vector<Vector3d, Eigen::aligned_allocator<Vector3d> >* > velocity_lists;
+    vector<vector_aligned<Vector3d>* > velocity_lists;
     velocity_lists.push_back(&close_panel_velocities);
     velocity_lists.push_back(&close_panel_edge_velocities);
     velocity_lists.push_back(&interior_close_panel_velocities);
@@ -1662,7 +1662,7 @@ Solver::compute_velocity_interpolated(const Eigen::Vector3d &x, std::set<int> &i
         if (velocity_lists[i]->size() > 0) {
             // Average:
             Vector3d velocity = Vector3d(0, 0, 0);
-            vector<Vector3d, Eigen::aligned_allocator<Vector3d> >::iterator it;
+            vector_aligned<Vector3d>::iterator it;
             for (it = velocity_lists[i]->begin(); it != velocity_lists[i]->end(); it++)
                 velocity += *it;
                 

--- a/vortexje/solver.hpp
+++ b/vortexje/solver.hpp
@@ -15,11 +15,11 @@
 #include <fstream>
 
 #include <Eigen/Core>
-#include <Eigen/StdVector>
 
 #include <vortexje/body.hpp>
 #include <vortexje/surface-writer.hpp>
 #include <vortexje/boundary-layer.hpp>
+#include <vortexje/vector-aligned.hpp>
 
 namespace Vortexje
 {
@@ -147,7 +147,7 @@ public:
         Eigen::Vector3d point;
     };
     
-    std::vector<SurfacePanelPoint, Eigen::aligned_allocator<SurfacePanelPoint> > trace_streamline(const SurfacePanelPoint &start) const;
+    vector_aligned<SurfacePanelPoint> trace_streamline(const SurfacePanelPoint &start) const;
     
     void log(int step_number, SurfaceWriter &writer) const;
 

--- a/vortexje/surface-builder.cpp
+++ b/vortexje/surface-builder.cpp
@@ -35,7 +35,7 @@ SurfaceBuilder::SurfaceBuilder(Surface &surface) : surface(surface)
    @returns A list of new node numbers.
 */
 vector<int>
-SurfaceBuilder::create_nodes_for_points(const vector<Vector3d, Eigen::aligned_allocator<Vector3d> > &points)
+SurfaceBuilder::create_nodes_for_points(const vector_aligned<Vector3d> &points)
 {
     vector<int> new_nodes;
     

--- a/vortexje/surface-builder.hpp
+++ b/vortexje/surface-builder.hpp
@@ -10,9 +10,9 @@
 #define __SURFACE_BUILDER_HPP__
 
 #include <Eigen/Core>
-#include <Eigen/StdVector>
 
 #include <vortexje/lifting-surface.hpp>
+#include <vortexje/vector-aligned.hpp>
 
 namespace Vortexje
 {
@@ -34,7 +34,7 @@ public:
     */
     Surface &surface;
     
-    std::vector<int> create_nodes_for_points(const std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > &points);
+    std::vector<int> create_nodes_for_points(const vector_aligned<Eigen::Vector3d> &points);
     
     std::vector<int> create_panels_between_shapes(const std::vector<int> &first_nodes, const std::vector<int> &second_nodes, bool cyclic = true);
     

--- a/vortexje/surface-writer.cpp
+++ b/vortexje/surface-writer.cpp
@@ -41,7 +41,7 @@ SurfaceWriter::write(const std::shared_ptr<Surface> &surface, const std::string 
                      int node_offset, int panel_offset)
 {
     vector<string> empty_names;
-    vector<MatrixXd, Eigen::aligned_allocator<MatrixXd> > empty_data;
+    vector_aligned<MatrixXd> empty_data;
     
     return write(surface, filename, 0, 0, empty_names, empty_data);
 }

--- a/vortexje/surface-writer.hpp
+++ b/vortexje/surface-writer.hpp
@@ -56,7 +56,7 @@ public:
     */               
     virtual bool write(const std::shared_ptr<Surface> &surface, const std::string &filename,
                        int node_offset, int panel_offset,
-                       const std::vector<std::string> &view_names, const std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> > &view_data) = 0;
+                       const std::vector<std::string> &view_names, const vector_aligned<Eigen::MatrixXd> &view_data) = 0;
 };
 
 };

--- a/vortexje/surface-writers/gmsh-surface-writer.cpp
+++ b/vortexje/surface-writers/gmsh-surface-writer.cpp
@@ -42,7 +42,7 @@ GmshSurfaceWriter::file_extension() const
 bool
 GmshSurfaceWriter::write(const std::shared_ptr<Surface> &surface, const string &filename, 
                          int node_offset, int panel_offset,
-                         const std::vector<std::string> &view_names, const vector<MatrixXd, Eigen::aligned_allocator<MatrixXd> > &view_data)
+                         const std::vector<std::string> &view_names, const vector_aligned<MatrixXd> &view_data)
 {
     cout << "Surface " << surface->id << ": Saving to " << filename << "." << endl;
     

--- a/vortexje/surface-writers/gmsh-surface-writer.hpp
+++ b/vortexje/surface-writers/gmsh-surface-writer.hpp
@@ -28,7 +28,7 @@ public:
                     
     bool write(const std::shared_ptr<Surface> &surface, const std::string &filename,
                int node_offset, int panel_offset,
-               const std::vector<std::string> &view_names, const std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> > &view_data);
+               const std::vector<std::string> &view_names, const vector_aligned<Eigen::MatrixXd> &view_data);
 };
 
 };

--- a/vortexje/surface-writers/vtk-surface-writer.cpp
+++ b/vortexje/surface-writers/vtk-surface-writer.cpp
@@ -42,7 +42,7 @@ VTKSurfaceWriter::file_extension() const
 bool
 VTKSurfaceWriter::write(const std::shared_ptr<Surface> &surface, const string &filename, 
                         int node_offset, int panel_offset,
-                        const std::vector<std::string> &view_names, const vector<MatrixXd, Eigen::aligned_allocator<MatrixXd> > &view_data)
+                        const std::vector<std::string> &view_names, const vector_aligned<MatrixXd> &view_data)
 {
     cout << "Surface " << surface->id << ": Saving to " << filename << "." << endl;
     

--- a/vortexje/surface-writers/vtk-surface-writer.hpp
+++ b/vortexje/surface-writers/vtk-surface-writer.hpp
@@ -28,7 +28,7 @@ public:
        
     bool write(const std::shared_ptr<Surface> &surface, const std::string &filename,
                int node_offset, int panel_offset,
-               const std::vector<std::string> &view_names, const std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> > &view_data);
+               const std::vector<std::string> &view_names, const vector_aligned<Eigen::MatrixXd> &view_data);
 };
 
 };

--- a/vortexje/surface.cpp
+++ b/vortexje/surface.cpp
@@ -267,7 +267,7 @@ Surface::compute_geometry(int panel)
     panel_coordinate_transformations[panel] = transformation;
     
     // Create transformed points.
-    vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > single_panel_transformed_points;
+    vector_aligned<Eigen::Vector3d> single_panel_transformed_points;
     single_panel_transformed_points.reserve(single_panel_nodes.size());
     for (int j = 0; j < (int) single_panel_nodes.size(); j++)
         single_panel_transformed_points.push_back(transformation * nodes[single_panel_nodes[j]]);

--- a/vortexje/surface.hpp
+++ b/vortexje/surface.hpp
@@ -16,9 +16,9 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <Eigen/StdVector>
 
 #include <vortexje/parameters.hpp>
+#include <vortexje/vector-aligned.hpp>
 
 namespace Vortexje
 {
@@ -59,7 +59,7 @@ public:
     /**
        Node number to point map.
     */
-    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > nodes;
+    vector_aligned<Eigen::Vector3d> nodes;
     
     /**
        Node number to neigboring panel numbers map.
@@ -88,7 +88,7 @@ public:
     /**
        Panel number to comprising vertex points (in the panel coordinate system) map.
     */
-    std::vector<std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > > panel_transformed_points;
+    std::vector<vector_aligned<Eigen::Vector3d> > panel_transformed_points;
     
     void rotate(const Eigen::Vector3d &axis, double angle);
     virtual void transform(const Eigen::Matrix3d &transformation);
@@ -123,17 +123,17 @@ protected:
     /**
        Panel number to collocation point map.
     */
-    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > panel_collocation_points[2];
+    vector_aligned<Eigen::Vector3d> panel_collocation_points[2];
     
     /**
        Panel number to normal map.
     */
-    std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > panel_normals;
+    vector_aligned<Eigen::Vector3d> panel_normals;
     
     /**
        Panel number to panel coordinate transformation map.
     */
-    std::vector<Eigen::Transform<double, 3, Eigen::Affine>, Eigen::aligned_allocator<Eigen::Transform<double, 3, Eigen::Affine> > > panel_coordinate_transformations;
+    vector_aligned<Eigen::Transform<double, 3, Eigen::Affine> > panel_coordinate_transformations;
     
     /**
        Panel number to surface area map.

--- a/vortexje/vector-aligned.hpp
+++ b/vortexje/vector-aligned.hpp
@@ -1,0 +1,17 @@
+//
+// Vortexje -- std::vector using eigen's aligned_allocator
+//
+
+#ifndef __ALIGNED_VECTOR_HPP__
+#define __ALIGNED_VECTOR_HPP__
+
+#include <vector>
+#include <Eigen/StdVector>
+
+namespace Vortexje
+{
+  template <typename T>
+  using vector_aligned = std::vector<T, Eigen::aligned_allocator<T> >;
+};
+
+#endif // __ALIGNED_VECTOR_HPP__


### PR DESCRIPTION
https://github.com/jbaayen/vortexje/blob/master/vortexje/solver.cpp#L1003 Fails to compile in recent eigen releases due to improper allocator definition.

A simple fix could be replacing:
```
vector<vector<Vector3d, Eigen::aligned_allocator<Vector3d> >, Eigen::aligned_allocator<vector<Vector3d> > > wake_velocities;
```
with:
```
vector<vector<Vector3d, Eigen::aligned_allocator<Vector3d> >, Eigen::aligned_allocator<vector<Vector3d, Eigen::aligned_allocator<Vector3d> > > > wake_velocities;
```

However, a more readable and less error prone solution is proposed by this pull request with the introduction of vector_aligned:
```
  template <typename T>
  using vector_aligned = std::vector<T, Eigen::aligned_allocator<T> >;
```